### PR TITLE
Added SendChatMessage method to IRC instance

### DIFF
--- a/Unity-Twitch-Chat/Assets/Package/Runtime/IRC.cs
+++ b/Unity-Twitch-Chat/Assets/Package/Runtime/IRC.cs
@@ -276,5 +276,19 @@ namespace Lexone.UnityTwitchChat
             if (showIRCDebug)
                 Debug.Log($"{Tags.alert} Disconnected from Twitch IRC");
         }
+
+        /// <summary>
+        /// Sends a chat message to the channel
+        /// </summary>
+        /// <param name="message">The message to send</param>
+        public void SendChatMessage(string message)
+        {
+            if (useAnonymousLogin)
+            {
+                Debug.LogWarning("Chat messages cannot be sent with anonymous login");
+                return;
+            }
+            connection.SendChatMessage(message);
+        }
     }
 }


### PR DESCRIPTION
I noticed there was no way to send a message to the chat from the IRC instance so added this simple method in that seems to work fine.